### PR TITLE
Reverting the changes; returned to commenting out rack-cors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'bcrypt', '~> 3.1.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem 'rack-cors'
+# gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,8 +107,6 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
-    rack-cors (1.1.1)
-      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.5)
@@ -189,7 +187,6 @@ DEPENDENCIES
   listen (~> 3.3)
   pg (~> 1.1)
   puma (~> 5.0)
-  rack-cors
   rails (~> 6.1.3, >= 6.1.3.2)
   rspec-json_expectations
   rspec-rails (~> 5.0.0)


### PR DESCRIPTION
Heroku app is down. In the Heroku logs, it mentioned that `rack-cors` was not included in the `Gemfile.lock` which led to the build failing.  However, upon experimenting with the deployment, I got the app to successfully build using a different Git branch. The absence of the gem isn't the root cause but rather has to do with changes that Heroku deems as incorrect paths. 

You can tail the errors in CLI: `heroku logs --tail`

Long story short, this merge is undoing the previous merges which involved (commenting out the gem, bundle install, git add ., git commit and merge into main). In other words, the main branch is reverting to when `authLogin` was merged in. 

